### PR TITLE
build.zig improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.zig-cache
 /zig-out
 *.stl
+/zig-cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A tiny simple zig library for loading STL files with support for both ASCII and 
 Example usage provided in [example.zig](src/example.zig):
 
 ```c
-const stlLoader = @import("./stl-loader-zig.zig");
+const stlLoader = @import("stl-loader");
 
 ...
 

--- a/build.zig
+++ b/build.zig
@@ -2,8 +2,11 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
-
     const optimize = b.standardOptimizeOption(.{});
+
+    const stl_loader = b.addModule("root", .{
+        .root_source_file = b.path("src/stl-loader-zig.zig"),
+    });
 
     const exe = b.addExecutable(.{
         .name = "stl-loader-zig",
@@ -11,6 +14,8 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+
+    exe.root_module.addImport("stl_loader", stl_loader);
 
     b.installArtifact(exe);
 
@@ -22,6 +27,6 @@ pub fn build(b: *std.Build) void {
         run_cmd.addArgs(args);
     }
 
-    const run_step = b.step("run", "Run the app");
+    const run_step = b.step("run", "Run the example");
     run_step.dependOn(&run_cmd.step);
 }

--- a/src/example.zig
+++ b/src/example.zig
@@ -12,18 +12,10 @@ pub fn main() !void {
     const mesh = try stlLoader.load_stl(allocator, filepath);
     defer allocator.free(mesh);
 
-    // read mesh from end to start
-    var t: stlLoader.Triangle = undefined;
-    var i = mesh.len - 1;
-    while (true) {
-        t = mesh[i];
+    // read mesh
+    for (mesh, 0..) |t, i| {
         std.debug.print("Triangle {d}:\n{d} {d} {d}\n", .{ i, t.v1.x, t.v1.y, t.v1.z });
         std.debug.print("{d} {d} {d}\n", .{ t.v2.x, t.v2.y, t.v2.z });
         std.debug.print("{d} {d} {d}\n", .{ t.v3.x, t.v3.y, t.v3.z });
-        if (i > 0) {
-            i -= 1;
-        } else {
-            break;
-        }
     }
 }

--- a/src/example.zig
+++ b/src/example.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const stlLoader = @import("./stl-loader-zig.zig");
+const stlLoader = @import("stl_loader");
 
 pub fn main() !void {
     // path relative to cwd
@@ -12,7 +12,7 @@ pub fn main() !void {
     const mesh = try stlLoader.load_stl(allocator, filepath);
     defer allocator.free(mesh);
 
-    // read mesh from end to start 
+    // read mesh from end to start
     var t: stlLoader.Triangle = undefined;
     var i = mesh.len - 1;
     while (true) {
@@ -20,6 +20,10 @@ pub fn main() !void {
         std.debug.print("Triangle {d}:\n{d} {d} {d}\n", .{ i, t.v1.x, t.v1.y, t.v1.z });
         std.debug.print("{d} {d} {d}\n", .{ t.v2.x, t.v2.y, t.v2.z });
         std.debug.print("{d} {d} {d}\n", .{ t.v3.x, t.v3.y, t.v3.z });
-        if (i>0) {i -= 1;} else {break;}
+        if (i > 0) {
+            i -= 1;
+        } else {
+            break;
+        }
     }
 }


### PR DESCRIPTION
I made a couple improvements to the build system. Mainly added the `b.addModule` that allows users to fetch and import the repo through Zig's build system. Then I added the `exe.root_module.addIport` part that allows the previous module to be imported in the example with the given name rather than the filepath. If you wish I could also add a How to use part in the README. 